### PR TITLE
Reworked challenge category scripts & styling

### DIFF
--- a/webapp/static/script.js
+++ b/webapp/static/script.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
-    let challenges = document.getElementById('challenge_submission')
-    if (challenges != null) manageChallanges(challenges);
+    if (document.getElementById('challenge_submission')) {
+        manageChallenges();
+    }
 
     if (window.location.pathname.startsWith('/scoreboard')) {
         manageScoreboard();
@@ -58,8 +59,27 @@ function updateUniversity(update_url) {
     });
 }
 
-function manageChallanges(challenge_container) {
+function showSelectedDifficulty() {
+    const challengeCategories = document.querySelectorAll('.challenge-category');
 
+    const difficultyFilter = document.getElementById('difficulty-filter');
+    const selectedDifficulty = difficultyFilter.options[difficultyFilter.selectedIndex].value;
+
+    challengeCategories.forEach((category) => category.classList.remove('show-easy', 'show-medium', 'show-hard', 'show-all'));
+    if (selectedDifficulty === 'all') {
+        challengeCategories.forEach((category) => category.classList.add('show-all'));
+    } else {
+        for (let category of challengeCategories) {
+            if (Array.from(category.querySelectorAll('.challenge')).find(
+                    el => el.classList.contains(selectedDifficulty))
+                ) {
+                category.classList.add(`show-${selectedDifficulty}`)
+            }
+        }
+    }
+}
+
+function manageChallenges() {
     //Make solves work properly
     const solves_links = document.querySelectorAll(".solves_link");
     for (let solves_link of solves_links) {
@@ -73,43 +93,6 @@ function manageChallanges(challenge_container) {
         });
     }
 
-    //find all of the challenges in a page
-    let challenges = [];
-    for (let accordion of challenge_container.children) {
-        Array.from(accordion.children).forEach(x => {if (x.className == "accordion-item") challenges.push(x)});
-    }
-
-    //Assign difficulty filters
-    let difficultyFilter = document.getElementById('difficulty-filter');
-    challenges.forEach(challenge => {
-        difficultyFilter.addEventListener('change', () => {
-            challenge.style.display = '';
-            
-            let difficulty = difficultyFilter.value;
-            if (challenge.getAttribute("difficulty")) {
-                switch (difficulty) {
-                    case 'easy':
-                        if (challenge.getAttribute("difficulty") != "easy") {
-                            challenge.style.display = 'none';
-                        }
-                        break;
-                    case 'medium':
-                        if (challenge.getAttribute("difficulty") != "medium") {
-                            challenge.style.display = 'none';
-                        }
-                        break;
-                    case 'hard':
-                        if (challenge.getAttribute("difficulty") != "hard") {
-                            challenge.style.display = 'none';
-                        }
-                        break;  
-                    default: 
-                        challenge.style.display = '';
-                }
-            };
-        });
-    });
-
     //allow submissions
     document.addEventListener('submit', async function (handleSubmit) {
         handleSubmit.preventDefault();
@@ -118,7 +101,8 @@ function manageChallanges(challenge_container) {
 
         //find challenge assosiated with sumbit
         let challengeId = form.getAttribute("challenge");
-        let challenge = challenges.find(x => x.id == challengeId);
+
+        let challenge = document.querySelector(`.challenge[id=${challengeId}]`);
         let inputField = form.children[0].children[0];
         let solvesText = challenge.getElementsByClassName("solves-count")[0];
         let challengeName = challenge.getElementsByClassName("challenge-name")[0];

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -17,6 +17,11 @@ main {
     margin: 0;
 }
 
+/* Disable BS button focus border */
+.accordion-button:focus {
+  box-shadow: none;
+}
+
 /* Custom css for the category cards in the challenge category overview*/
 .challenge-card {
     width: 300px;
@@ -128,6 +133,21 @@ button {
 .solves_link {
   color: black;
   text-decoration: none;
+  border-color: #cfe2ff!important
+}
+
+.solves_link:hover {
+  transition: color .15s;
+  background-color: #EBF3F5;
+}
+
+.accordion-button:not(.collapsed) .solves_link {
+  border-color: darkgrey!important
+}
+
+.accordion-button:not(.collapsed) .solves_link:hover {
+  transition: color .15s;
+  background-color: #949d9e;
 }
 
 form {

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -23,6 +23,25 @@ main {
     padding: 15px;
 }
 
+/* Don't show challenge categories or the challenges within by default*/
+.challenge-category,
+.challenge {
+  display: none;
+}
+
+/* Show challenge-categories with one of these classes */
+.show-all,
+.show-easy,
+.show-medium,
+.show-hard,
+/* Show correctly filtered challenges within a shown category */
+.show-all .challenge,
+.show-easy .challenge.easy,
+.show-medium .challenge.medium,
+.show-hard .challenge.hard {
+  display: block;
+}
+
 /* Custom css for 'code blocks' used in connection strings */
 .code-block {
   background-color: #f0f0f0;

--- a/webapp/templates/challenges_category.html
+++ b/webapp/templates/challenges_category.html
@@ -2,8 +2,15 @@
 {% block title %}pwncrates - {{category}}{% endblock %}
 
 {% block content %}
-<div class="container">
-  <div class="filter row mb-5">
+<div class="d-flex flex-row justify-content-start mb-5">
+  <a href="/challenges" class="me-3">
+    <button class="btn" style="width: fit-content;">
+      <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" fill="currentColor" class="bi bi-arrow-left-square" viewBox="0 0 16 16">
+        <path fill-rule="evenodd" d="M15 2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2zM0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm11.5 5.5a.5.5 0 0 1 0 1H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H11.5z"/>
+      </svg>
+    </button>
+  </a>
+  <div class="filter w-100">
       <select id="difficulty-filter" name="difficulty-filter" autocomplete="off" onChange="showSelectedDifficulty()">
           <option value="all">All</option>
           <option value="easy">Easy</option>
@@ -11,60 +18,60 @@
           <option value="hard">Hard</option>
       </select>
   </div>
-  <div id="challenge_submission" class="challenge_submission row">
-  {% for name, subcategory_description, challenges in subcategories %}
-  <div class="challenge-category accordion accordion-flush show-all">
-      <h4>{{ name }}</h4>
-      <p>{{ subcategory_description }}</p>
-      {% for challenge_id, name, description, points, url, challenge_solves, handout, difficulty in challenges %}
-        <div class="accordion-item border challenge {{difficulty}}" id="{{challenge_id}}">
-          <div class="accordion-header">
-            <button class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#{{challenge_id}}-info" aria-controls="{{challenge_id}}-info">
-              <div class="d-flex flex-row justify-content-between w-100">
-                <div>
-                  <h4 class="mb-0 challenge-name {% if challenge_id in solves %}solved{% endif %}">[{{points}}] {{name}}</h4>
-                </div>
-                <a href="/solves/{{challenge_id}}" class="solves_link py-1 px-2 me-3 rounded border"><h4 class="mb-0">{{challenge_solves}} solves</h4></a>
+</div>
+<div id="challenge_submission" class="challenge_submission row">
+{% for name, subcategory_description, challenges in subcategories %}
+<div class="challenge-category accordion accordion-flush show-all">
+    <h4>{{ name }}</h4>
+    <p>{{ subcategory_description }}</p>
+    {% for challenge_id, name, description, points, url, challenge_solves, handout, difficulty in challenges %}
+      <div class="accordion-item border challenge {{difficulty}}" id="{{challenge_id}}">
+        <div class="accordion-header">
+          <button class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#{{challenge_id}}-info" aria-controls="{{challenge_id}}-info">
+            <div class="d-flex flex-row justify-content-between w-100">
+              <div>
+                <h4 class="mb-0 challenge-name {% if challenge_id in solves %}solved{% endif %}">[{{points}}] {{name}}</h4>
               </div>
-            </button>
-          </div>
-          <div id="{{challenge_id}}-info" class="accordion-collapse collapse">
-            <div class="accordion-body">
-                  <p>
-                      {{description | safe}}
-                  </p>
-                  {% if url != "Null" %}
-                  <div class="code-block"><p>
-                      {{ url }}
-                  </p></div>
-                  {% endif %}
-  
-                  {% if handout != "" %}
-                  <a href="{{ url_for('static', filename='handouts/' + handout) }}">Download files</a>
-                  {% endif %}
-  
-                  {% if current_user.is_authenticated %}
-                  <p id="solved" style="{% if challenge_id not in solves %}display: none;{% endif %}">
-                      Solved! <a href="{{ url_for('writeups', challenge_id=challenge_id ) }}">View writeups</a>
-                  </p>
-                  <form onSubmit="handleChallengeSubmission(event)" challenge="{{challenge_id}}" style="{% if challenge_id in solves %}display: none;{% endif %}"
-                        method="POST" action="/api/challenges/submit/{{challenge_id}}">
-                      <div class="input-group mb-3">
-                          <input type="text" name="flag" class="form-control" autocomplete="off" placeholder="Submit flag" id="{{challenge_id}}">
-                          <button class="btn btn-primary" type="submit" id="button-addon2">Submit</button>
-                      </div>
-                  </form>
-                  {% else %}
-                  <p>
-                      <i>You must be logged in to submit flags</i>
-                  </p>
-                  {% endif %}
+              <a href="/solves/{{challenge_id}}" class="solves_link py-1 px-2 me-3 rounded border"><h4 class="mb-0">{{challenge_solves}} solves</h4></a>
             </div>
+          </button>
+        </div>
+        <div id="{{challenge_id}}-info" class="accordion-collapse collapse">
+          <div class="accordion-body">
+                <p>
+                    {{description | safe}}
+                </p>
+                {% if url != "Null" %}
+                <div class="code-block"><p>
+                    {{ url }}
+                </p></div>
+                {% endif %}
+
+                {% if handout != "" %}
+                <a href="{{ url_for('static', filename='handouts/' + handout) }}">Download files</a>
+                {% endif %}
+
+                {% if current_user.is_authenticated %}
+                <p id="solved" style="{% if challenge_id not in solves %}display: none;{% endif %}">
+                    Solved! <a href="{{ url_for('writeups', challenge_id=challenge_id ) }}">View writeups</a>
+                </p>
+                <form onSubmit="handleChallengeSubmission(event)" challenge="{{challenge_id}}" style="{% if challenge_id in solves %}display: none;{% endif %}"
+                      method="POST" action="/api/challenges/submit/{{challenge_id}}">
+                    <div class="input-group mb-3">
+                        <input type="text" name="flag" class="form-control" autocomplete="off" placeholder="Submit flag" id="{{challenge_id}}">
+                        <button class="btn btn-primary" type="submit" id="button-addon2">Submit</button>
+                    </div>
+                </form>
+                {% else %}
+                <p>
+                    <i>You must be logged in to submit flags</i>
+                </p>
+                {% endif %}
           </div>
         </div>
-      {% endfor %}
-  </div>
-  {% endfor %}
-  </div>
+      </div>
+    {% endfor %}
 </div>
+{% endfor %}
+  </div>
 {% endblock %}

--- a/webapp/templates/challenges_category.html
+++ b/webapp/templates/challenges_category.html
@@ -4,8 +4,8 @@
 {% block content %}
 <div class="container">
   <div class="filter row mb-5">
-      <select id="difficulty-filter" autocomplete="off" aria-label="All">
-          <option value="">All</option>
+      <select id="difficulty-filter" name="difficulty-filter" autocomplete="off" onChange="showSelectedDifficulty()">
+          <option value="all">All</option>
           <option value="easy">Easy</option>
           <option value="medium">Medium</option>
           <option value="hard">Hard</option>
@@ -13,18 +13,16 @@
   </div>
   <div id="challenge_submission" class="challenge_submission row">
   {% for name, subcategory_description, challenges in subcategories %}
-  <div class="accordion">
+  <ul class="challenge-category accordion accordion-flush show-all">
       <h4>{{ name }}</h4>
       <p>{{ subcategory_description }}</p>
       {% for challenge_id, name, description, points, url, challenge_solves, handout, difficulty in challenges %}
-        <div class="accordion-item" difficulty="{{difficulty}}" id="{{challenge_id}}">
+        <div class="accordion-item border challenge {{difficulty}}" id="{{challenge_id}}">
           <div class="accordion-header">
-            <div class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#{{challenge_id}}-info"
-                    aria-expanded="true" aria-controls="{{challenge_id}}-info">
+            <div class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#{{challenge_id}}-info" aria-controls="{{challenge_id}}-info">
                 <div class="d-flex row w-100">
                     <div class="col-md">
-
-                        <h4 class="{% if challenge_id in solves %}solved{% endif %} challenge-name">[{{points}}] {{name}}</h4>
+                        <h4 class="challenge-name {% if challenge_id in solves %}solved{% endif %}">[{{points}}] {{name}}</h4>
                     </div>
                   <div class="col-md"><h4>
                       <span class="float-end solves-count"><a href="/solves/{{challenge_id}}" class="solves_link">{{challenge_solves}} solves</a></span>
@@ -67,7 +65,7 @@
           </div>
         </div>
       {% endfor %}
-  </div>
+  </ul>
   {% endfor %}
   </div>
 </div>

--- a/webapp/templates/challenges_category.html
+++ b/webapp/templates/challenges_category.html
@@ -19,7 +19,7 @@
       </select>
   </div>
 </div>
-<div id="challenge_submission" class="challenge_submission row">
+<div id="challenge_submission" class="challenge_submission">
 {% for name, subcategory_description, challenges in subcategories %}
 <div class="challenge-category accordion accordion-flush show-all">
     <h4>{{ name }}</h4>

--- a/webapp/templates/challenges_category.html
+++ b/webapp/templates/challenges_category.html
@@ -13,23 +13,21 @@
   </div>
   <div id="challenge_submission" class="challenge_submission row">
   {% for name, subcategory_description, challenges in subcategories %}
-  <ul class="challenge-category accordion accordion-flush show-all">
+  <div class="challenge-category accordion accordion-flush show-all">
       <h4>{{ name }}</h4>
       <p>{{ subcategory_description }}</p>
       {% for challenge_id, name, description, points, url, challenge_solves, handout, difficulty in challenges %}
         <div class="accordion-item border challenge {{difficulty}}" id="{{challenge_id}}">
           <div class="accordion-header">
-            <div class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#{{challenge_id}}-info" aria-controls="{{challenge_id}}-info">
-                <div class="d-flex row w-100">
-                    <div class="col-md">
-                        <h4 class="challenge-name {% if challenge_id in solves %}solved{% endif %}">[{{points}}] {{name}}</h4>
-                    </div>
-                  <div class="col-md"><h4>
-                      <span class="float-end solves-count"><a href="/solves/{{challenge_id}}" class="solves_link">{{challenge_solves}} solves</a></span>
-                  </h4></div>
+            <button class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#{{challenge_id}}-info" aria-controls="{{challenge_id}}-info">
+              <div class="d-flex flex-row justify-content-between w-100">
+                <div>
+                  <h4 class="mb-0 challenge-name {% if challenge_id in solves %}solved{% endif %}">[{{points}}] {{name}}</h4>
                 </div>
+                <a href="/solves/{{challenge_id}}" class="solves_link py-1 px-2 me-3 rounded border"><h4 class="mb-0">{{challenge_solves}} solves</h4></a>
               </div>
-            </div>
+            </button>
+          </div>
           <div id="{{challenge_id}}-info" class="accordion-collapse collapse">
             <div class="accordion-body">
                   <p>
@@ -49,7 +47,7 @@
                   <p id="solved" style="{% if challenge_id not in solves %}display: none;{% endif %}">
                       Solved! <a href="{{ url_for('writeups', challenge_id=challenge_id ) }}">View writeups</a>
                   </p>
-                  <form challenge="{{challenge_id}}" style="{% if challenge_id in solves %}display: none;{% endif %}"
+                  <form onSubmit="handleChallengeSubmission(event)" challenge="{{challenge_id}}" style="{% if challenge_id in solves %}display: none;{% endif %}"
                         method="POST" action="/api/challenges/submit/{{challenge_id}}">
                       <div class="input-group mb-3">
                           <input type="text" name="flag" class="form-control" autocomplete="off" placeholder="Submit flag" id="{{challenge_id}}">
@@ -65,7 +63,7 @@
           </div>
         </div>
       {% endfor %}
-  </ul>
+  </div>
   {% endfor %}
   </div>
 </div>


### PR DESCRIPTION
Challenges are now shown and hidden by applying/removing utility CSS classes.

Fixed the links in the challenge accordion headers so you don't need to mess with mouse events to toggle their activation. Also tried to make it more obvious they're links.

Changed styling on challenge accordion items with accordion-flush. They're now square instead of rounded, but it fixes some of the borders being absent when some items of a multi-item accordion are hidden due to difficulty filtering. There isn't a better way I can think of to fix this unless you want to reimplement a more custom solution, it's just how Boostrap handles accordions. If you did I'd start with [Bootstrap collapses](https://getbootstrap.com/docs/5.3/components/collapse/).

Added a back button to return to the challenge overview page from challenge categories.

Changed scripts on /challenges/:category pages to be called with HTML attributes (onChange, onSubmit, etc.). I wasn't able to test the challenge submission forms or anything while being logged in, so it's possible that's slightly broken.